### PR TITLE
Implements a new environment named fullwidthfig

### DIFF
--- a/dissertation.cls
+++ b/dissertation.cls
@@ -69,6 +69,30 @@
     \restoregeometry
 }
 
+% implements a new environment for figures, tables, etc
+% that are able to spread the full width of the page,
+% while keeping the caption on the side margin
+\newlength{\fullwidthlen}
+\setlength{\fullwidthlen}{\marginparwidth}
+\addtolength{\fullwidthlen}{\marginparsep}
+\newenvironment{fullwidthfig}{%
+  \begin{adjustwidth*}{}{-\fullwidthlen}%
+}{%
+  \end{adjustwidth*}%
+}
+
+% Example on how to use the fullwidthfig env
+% \begin{figure}[t]
+%   \begin{fullwidth}
+%     \includegraphics[width=\linewidth+\marginparsep]{demo}
+%   \end{fullwidth}
+%   \vspace{-\baselineskip}\vspace{-\baselineskip}
+%   \sideparmargin{outer}
+%   \sidepar{\vspace{\baselineskip}
+%     \caption{Caption for a full-width figure appearing in the margin
+%       below it.}}
+% \end{figure}
+
 \pagestyle{diss}
 
 %%% Part Style %%%


### PR DESCRIPTION
This new environment allows for figures, tables, etc to spread the full width of the page while keeping the caption on the side margin (solution to issue #3).

This is an example on how to use it:
```
\begin{figure}[t]
  \begin{fullwidth}
    \includegraphics[width=\linewidth+\marginparsep]{demo}
  \end{fullwidth}
  \vspace{-\baselineskip}\vspace{-\baselineskip}
  \sideparmargin{outer}
  \sidepar{\vspace{\baselineskip}
    \caption{Caption for a full-width figure appearing in the margin
      below it.}}
\end{figure}
```

And the rendered result:
![image](https://user-images.githubusercontent.com/65070/63068468-99e3a080-bee9-11e9-9ca0-3d9e4668c4cf.png)

